### PR TITLE
Bumping lodash.template version to 3.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "gulp-util": "~3.0.0",
-    "lodash.template": "~2.4.1",
+    "lodash.template": "~3.6.2",
     "through2": "~0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey! A really simple PR - just bumped the lodash version (The current version requires _ to be the in the global namespace, 3.6.2 doesn't).

Thanks!