### PR TITLE
fix of 'lodash.template' call

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (options) {
 
         var NSwrapper = '\n\n' + namespace.namespace + '["'+ name.replace(/\\/g, '/') +'"] = ';
 
-        var template = tpl(file.contents.toString(), false, options.templateSettings).source;
+        var template = tpl(file.contents.toString(), options.templateSettings).source;
 
         return templateHeader + NSwrapper + template + '})();';
     }


### PR DESCRIPTION
in lodash.template 4.2.5 there is no more data as second argument
`function template(string, options, guard) {...}`