### PR TITLE
Added new option to remove IIFE encapsulation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,13 +31,16 @@ module.exports = function (options) {
     function compiler (file) {
         var name = typeof options.name === 'function' && options.name(file) || file.relative;
         var namespace = getNamespaceDeclaration(options.namespace || 'JST');
-        var templateHeader = '(function() {\n' + namespace.declaration;
+		var IIFE_start = options.IIFE !== false ? '(function() {\n':'';
+		var IIFE_end = options.IIFE !== false ? '})();':'';
+		
+        var templateHeader = IIFE_start + namespace.declaration;
 
         var NSwrapper = '\n\n' + namespace.namespace + '["'+ name.replace(/\\/g, '/') +'"] = ';
 
         var template = tpl(file.contents.toString(), options.templateSettings).source;
 
-        return templateHeader + NSwrapper + template + '})();';
+        return templateHeader + NSwrapper + template + IIFE_end;
     }
 
     var stream = through.obj(function (file, enc, callback) {

--- a/test.js
+++ b/test.js
@@ -80,3 +80,66 @@ it('should support dot paths in namespace', function (cb) {
 		contents: new Buffer('<h1><%= test %></h1>')
 	}));
 });
+
+it('shouldn´t generate IIFE encapsulation', function(cb) {
+
+	var stream = tpl(
+	{
+		IIFE:false
+	});
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, __dirname + '\\fixture\\fixture.js');
+		assert.equal(file.relative, 'fixture\\fixture.js');
+		assert.equal(/\(function\(\) \{/.test(file.contents.toString()),false);
+		assert.equal(/\}\)\(\);/.test(file.contents.toString()),false);
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		base: __dirname,
+		path: __dirname + '/fixture/fixture.html',
+		contents: new Buffer('<h1><%= test %></h1>')
+	}));
+});
+
+it('should generate IIFE encapsulation with specific configuration', function(cb) {
+
+	var stream = tpl(
+	{
+		IIFE:true
+	});
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, __dirname + '\\fixture\\fixture.js');
+		assert.equal(file.relative, 'fixture\\fixture.js');
+		assert(/\(function\(\) \{/.test(file.contents.toString()));
+		assert(/\}\)\(\);/.test(file.contents.toString()));
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		base: __dirname,
+		path: __dirname + '/fixture/fixture.html',
+		contents: new Buffer('<h1><%= test %></h1>')
+	}));
+});
+
+it('should generate IIFE encapsulation without configuration', function(cb) {
+
+	var stream = tpl();
+
+	stream.on('data', function (file) {
+		assert.equal(file.path, __dirname + '\\fixture\\fixture.js');
+		assert.equal(file.relative, 'fixture\\fixture.js');
+		assert(/\(function\(\) \{/.test(file.contents.toString()));
+		assert(/\}\)\(\);/.test(file.contents.toString()));
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		base: __dirname,
+		path: __dirname + '/fixture/fixture.html',
+		contents: new Buffer('<h1><%= test %></h1>')
+	}));
+});


### PR DESCRIPTION
Hello.

I found your library very useful, but when there are a lot of templetes and I want to concatenate all of them in a single file I fount that the IIFE encapsulation is repeated in each generation and I find it useless. I have added a new configuration parameter to avoid generating this lines. 

I have commit the change and some code testing it, and I have applied it in a big project and it works correctly. 

¿can you review it and merge it? Tell me if something is wrong and I will modify it. 

Regards.