### PR TITLE
Remove gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
-var gutil = require('gulp-util');
 var through = require('through2');
 var tpl = require('lodash.template');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
+var replaceExtension = require('replace-ext');
 
 var PLUGIN_NAME = 'gulp-template-compile';
 
@@ -33,7 +33,7 @@ module.exports = function (options) {
         var namespace = getNamespaceDeclaration(options.namespace || 'JST');
 		var IIFE_start = options.IIFE !== false ? '(function() {\n':'';
 		var IIFE_end = options.IIFE !== false ? '})();':'';
-		
+
         var templateHeader = IIFE_start + namespace.declaration;
 
         var NSwrapper = '\n\n' + namespace.namespace + '["'+ name.replace(/\\/g, '/') +'"] = ';
@@ -61,7 +61,7 @@ module.exports = function (options) {
             var compiled = compiler(file);
 
             file.contents = new Buffer(compiled);
-            file.path = gutil.replaceExtension(file.path, '.js');
+            file.path = replaceExtension(file.path, '.js');
         } catch (err) {
             this.emit('error', new PluginError(PLUGIN_NAME, err, {fileName: filePath}));
             return callback();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-template-compile",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Gulp task to precompile lodash templates",
   "main": "index.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gulp-util": "~3.0.0",
-    "lodash.template": "~4.2.5",
-    "through2": "~0.5.1"
+    "lodash.template": "~4.4.0",
+    "plugin-error": "^1.0.1",
+    "replace-ext": "^1.0.0",
+    "through2": "~0.6.1"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "vinyl": "^2.2.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 'use strict';
 var assert = require('assert');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var tpl = require('./index');
 
 it('should precompile lodash templates', function(cb) {
@@ -15,7 +15,7 @@ it('should precompile lodash templates', function(cb) {
 		cb();
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: __dirname + '/fixture/fixture.html',
 		contents: new Buffer('<h1><%= test %></h1>')
@@ -36,7 +36,7 @@ it('should support supplying custom name in a callback', function (cb) {
 		cb();
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: __dirname + '/fixture/fixture.html',
 		contents: new Buffer('<h1><%= test %></h1>')
@@ -55,7 +55,7 @@ it('should support supplying a custom namespace', function (cb) {
 		cb();
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: __dirname + '/fixture/fixture.html',
 		contents: new Buffer('<h1><%= test %></h1>')
@@ -74,7 +74,7 @@ it('should support dot paths in namespace', function (cb) {
 		cb();
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: __dirname + '/fixture/fixture.html',
 		contents: new Buffer('<h1><%= test %></h1>')
@@ -96,7 +96,7 @@ it('shouldn´t generate IIFE encapsulation', function(cb) {
 		cb();
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: __dirname + '/fixture/fixture.html',
 		contents: new Buffer('<h1><%= test %></h1>')
@@ -118,7 +118,7 @@ it('should generate IIFE encapsulation with specific configuration', function(cb
 		cb();
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: __dirname + '/fixture/fixture.html',
 		contents: new Buffer('<h1><%= test %></h1>')
@@ -137,7 +137,7 @@ it('should generate IIFE encapsulation without configuration', function(cb) {
 		cb();
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: __dirname + '/fixture/fixture.html',
 		contents: new Buffer('<h1><%= test %></h1>')


### PR DESCRIPTION
As `gulp-util` is deprecated, I have removed it and replaced it with the suggested replacements. I've also taken the liberty to update `lodash.template` and `through2` to their latest (compatible) versions.